### PR TITLE
Add aliases to improve routes maintenance.

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,8 +1,8 @@
 ---
 import Layout from "../layouts/Layout.astro";
-import Events from "../components/Events";
+import Events from "@components/Events";
 import Unete from "../components/Unete.astro";
-import Soon from '../components/Soon.astro'
+import Soon from "../components/Soon.astro";
 import "../components/cssInicio/variables.css";
 import "../components/cssInicio/fondo.css";
 import "../components/cssInicio/navInicio.css";
@@ -13,21 +13,13 @@ import Titulos from "../components/Titulos.astro";
 ---
 
 <Layout title="Welcome to StudentWebHub">
-    <Inicio />
-    <Titulos
-      titulo="Evéntos"
-    />
-    <Events />
-    <Titulos 
-      titulo="Próximo"  
-    />
-    <Soon />
-    <Titulos 
-     titulo="Únete" 
-    />
-    <Unete />
-    <Titulos 
-      titulo="FAQ"  
-    />
-    <Footer/>
+  <Inicio />
+  <Titulos titulo="Evéntos" />
+  <Events client:load />
+  <Titulos titulo="Próximo" />
+  <Soon />
+  <Titulos titulo="Únete" />
+  <Unete />
+  <Titulos titulo="FAQ" />
+  <Footer />
 </Layout>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,11 @@
   "extends": "astro/tsconfigs/strict",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "jsxImportSource": "react"
+    "jsxImportSource": "react",
+    "baseUrl": ".",
+    "paths": {
+      "@components/*": ["src/components/*"],
+      "@assets/*": ["src/assets/*"]
+    }
   }
 }


### PR DESCRIPTION
# Add aliases to improve routes maintenance.
## For example:

### 'Events' component from _**src/pages/index.astro**_
`import Events from "../components/Events";`  →  `import Events from "@components/Events";`

Official documentation to review the implementation process: [https://docs.astro.build/en/guides/aliases/](url)